### PR TITLE
Add analytics events and instrument searches

### DIFF
--- a/app/components/Map/MapRenderer.jsx
+++ b/app/components/Map/MapRenderer.jsx
@@ -115,7 +115,7 @@ export function MapRenderer(props) {
       const lat = e.lngLat.lat.toFixed(6);
       const lng = e.lngLat.lng.toFixed(6);
       // console.log("Updating coordinates:", lat, lng);
-      searchCoords(lat, lng);
+      searchCoords(lat, lng, { source: "map_double_click" });
       handleCoordinateUpdate(lat, lng);
     };
     map.on("dblclick", handler);

--- a/app/components/history-panel/history-card-large.tsx
+++ b/app/components/history-panel/history-card-large.tsx
@@ -1,13 +1,14 @@
 import { MapSnip } from "./map-snip";
 import { useMap } from "@/lib/context/mapContext";
 import { useMainStore } from "@/lib/store/mainStore";
-import { parseInput, searchCoords } from "@/lib/helpers/search";
+import { searchCoords } from "@/lib/helpers/search";
 import { timestampToRelativeTime } from "@/lib/helpers/conversions";
 import { useEffect, useState } from "react";
+import { trackHistoryReplayUsed } from "@/lib/analytics/events";
 
 export default function HistoryCardLarge({ item }: { item: HistoryItem }) {
   const { handleCoordinateUpdate } = useMap();
-  const { setSearchInput, clearCoordsResults } = useMainStore();
+  const { clearCoordsResults } = useMainStore();
   const { setHistoryPanelOpen } = useMainStore();
   const [relativeTime, setRelativeTime] = useState(
     timestampToRelativeTime(item.timestamp)
@@ -29,7 +30,11 @@ export default function HistoryCardLarge({ item }: { item: HistoryItem }) {
   const handleClick = () => {
     clearCoordsResults();
     handleCoordinateUpdate(item.lat, item.lng);
-    searchCoords(item.lat, item.lng, false);
+    trackHistoryReplayUsed({ card_size: "large" });
+    searchCoords(item.lat, item.lng, {
+      addHistory: false,
+      source: "history_replay",
+    });
     setHistoryPanelOpen(false);
   };
 

--- a/app/components/history-panel/history-card-small.tsx
+++ b/app/components/history-panel/history-card-small.tsx
@@ -2,12 +2,12 @@ import { timestampToRelativeTime } from "@/lib/helpers/conversions";
 import { useEffect, useState } from "react";
 import { useMap } from "@/lib/context/mapContext";
 import { useMainStore } from "@/lib/store/mainStore";
-import { parseInput } from "@/lib/helpers/search";
 import { searchCoords } from "@/lib/helpers/search";
+import { trackHistoryReplayUsed } from "@/lib/analytics/events";
 
 export default function HistoryCardSmall({ item }: { item: HistoryItem }) {
   const { handleCoordinateUpdate } = useMap();
-  const { setSearchInput, clearCoordsResults } = useMainStore();
+  const { clearCoordsResults } = useMainStore();
   const [relativeTime, setRelativeTime] = useState(
     timestampToRelativeTime(item.timestamp)
   );
@@ -28,7 +28,11 @@ export default function HistoryCardSmall({ item }: { item: HistoryItem }) {
   const handleClick = () => {
     clearCoordsResults();
     handleCoordinateUpdate(item.lat, item.lng);
-    searchCoords(item.lat, item.lng, false);
+    trackHistoryReplayUsed({ card_size: "small" });
+    searchCoords(item.lat, item.lng, {
+      addHistory: false,
+      source: "history_replay",
+    });
   };
 
   const trimmedInputContent =

--- a/app/components/search-panel/magic-button.tsx
+++ b/app/components/search-panel/magic-button.tsx
@@ -3,6 +3,7 @@ import { Clipboard } from "lucide-react";
 import { useMainStore } from "@/lib/store/mainStore";
 import { searchCoords } from "@/lib/helpers/search";
 import { useMap } from "@/lib/context/mapContext";
+import { trackPasteGoUsed } from "@/lib/analytics/events";
 import { toast } from "sonner";
 
 export default function PasteGoButton() {
@@ -15,14 +16,17 @@ export default function PasteGoButton() {
       console.log("paste & go", text);
       const [lat, lng] = text.split(",").map((v) => parseFloat(v.trim()));
       if (!isNaN(lat) && !isNaN(lng)) {
+        trackPasteGoUsed({ status: "success" });
         setSearchInput(text);
         handleCoordinateUpdate(lat, lng);
-        await searchCoords(lat, lng);
+        await searchCoords(lat, lng, { source: "paste_go" });
       } else {
+        trackPasteGoUsed({ status: "invalid_clipboard" });
         // Optionally show error/feedback
         toast.error("Clipboard does not contain valid coordinates.");
       }
     } catch (err) {
+      trackPasteGoUsed({ status: "clipboard_error" });
       toast.error("Error: " + err);
     }
   };

--- a/app/components/search-panel/search-panel.tsx
+++ b/app/components/search-panel/search-panel.tsx
@@ -30,25 +30,37 @@ export default function SearchPanel() {
   }, [input]);
 
   const fetcher = async (name: string) => {
+    const queryLength = name.trim().length;
+    let response: Awaited<ReturnType<typeof searchLocationsByName>>;
+
     try {
-      const response = await searchLocationsByName(name, 10);
-      const success = Array.isArray(response?.data);
-
-      trackSearchName({
-        query_length: name.trim().length,
-        success,
-        result_count: success ? response.data.length : 0,
-      });
-
-      return response;
+      response = await searchLocationsByName(name, 10);
     } catch (error) {
       trackSearchName({
-        query_length: name.trim().length,
+        query_length: queryLength,
         success: false,
         result_count: 0,
       });
       throw error;
     }
+
+    if (response.error) {
+      trackSearchName({
+        query_length: queryLength,
+        success: false,
+        result_count: 0,
+      });
+      throw response.error;
+    }
+
+    const normalizedData = Array.isArray(response.data) ? response.data : [];
+    trackSearchName({
+      query_length: queryLength,
+      success: true,
+      result_count: normalizedData.length,
+    });
+
+    return { data: normalizedData, error: null };
   };
 
   const {

--- a/app/components/search-panel/search-panel.tsx
+++ b/app/components/search-panel/search-panel.tsx
@@ -13,6 +13,7 @@ import { searchCoords } from "@/lib/helpers/search";
 import useSWR from "swr";
 import { searchLocationsByName } from "@/lib/actions/search";
 import { useMap } from "@/lib/context/mapContext";
+import { trackSearchName } from "@/lib/analytics/events";
 import SearchResultCard from "./search-result-card";
 
 export default function SearchPanel() {
@@ -28,7 +29,27 @@ export default function SearchPanel() {
     return parseInput(input);
   }, [input]);
 
-  const fetcher = (name: string) => searchLocationsByName(name, 10);
+  const fetcher = async (name: string) => {
+    try {
+      const response = await searchLocationsByName(name, 10);
+      const success = Array.isArray(response?.data);
+
+      trackSearchName({
+        query_length: name.trim().length,
+        success,
+        result_count: success ? response.data.length : 0,
+      });
+
+      return response;
+    } catch (error) {
+      trackSearchName({
+        query_length: name.trim().length,
+        success: false,
+        result_count: 0,
+      });
+      throw error;
+    }
+  };
 
   const {
     searchWindowState,
@@ -187,7 +208,7 @@ export default function SearchPanel() {
                 const [lat, lng] = input
                   .split(",")
                   .map((v) => parseFloat(v.trim()));
-                searchCoords(lat, lng);
+                searchCoords(lat, lng, { source: "search_panel" });
                 handleCoordinateUpdate(lat, lng);
               }}
             >

--- a/app/components/sidebar/service-area-button.tsx
+++ b/app/components/sidebar/service-area-button.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { pushModal } from "@/components/dialogs";
-import { Fuel, MapPin } from "lucide-react";
+import { Fuel } from "lucide-react";
+import { trackOpenServiceAreaReference } from "@/lib/analytics/events";
 
 export default function ServiceAreaButton() {
   return (
@@ -9,6 +10,7 @@ export default function ServiceAreaButton() {
       className="justify-start"
       icon={<Fuel className="size-4 text-muted-foreground" />}
       onClick={() => {
+        trackOpenServiceAreaReference();
         pushModal("ServiceAreasReference");
       }}
     >

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -2,7 +2,7 @@ import { track } from "@vercel/analytics/react";
 
 type TrackableProperties = Record<
   string,
-  string | number | boolean | null | undefined
+  string | number | boolean | null
 >;
 
 type AnalyticsEventName =

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -1,0 +1,75 @@
+import { track } from "@vercel/analytics/react";
+
+type TrackableProperties = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+type AnalyticsEventName =
+  | "search_coordinates"
+  | "search_name"
+  | "open_service_area_reference"
+  | "history_replay_used"
+  | "paste_go_used";
+
+export type CoordinateSearchSource =
+  | "search_panel"
+  | "map_double_click"
+  | "history_replay"
+  | "paste_go";
+
+export type CoordinateSearchErrorType =
+  | "none"
+  | "no_results"
+  | "request_failed";
+
+export type PasteGoStatus =
+  | "success"
+  | "invalid_clipboard"
+  | "clipboard_error";
+
+const safeTrack = (
+  name: AnalyticsEventName,
+  properties?: TrackableProperties
+) => {
+  if (typeof window === "undefined") return;
+
+  try {
+    track(name, properties);
+  } catch (error) {
+    console.error(`[analytics] Failed to track "${name}"`, error);
+  }
+};
+
+export const trackSearchCoordinates = (properties: {
+  source: CoordinateSearchSource;
+  success: boolean;
+  result_count: number;
+  error_type: CoordinateSearchErrorType;
+}) => {
+  safeTrack("search_coordinates", properties);
+};
+
+export const trackSearchName = (properties: {
+  query_length: number;
+  success: boolean;
+  result_count: number;
+}) => {
+  safeTrack("search_name", properties);
+};
+
+export const trackOpenServiceAreaReference = () => {
+  safeTrack("open_service_area_reference");
+};
+
+export const trackHistoryReplayUsed = (properties: {
+  card_size: "small" | "large";
+}) => {
+  safeTrack("history_replay_used", properties);
+};
+
+export const trackPasteGoUsed = (properties: {
+  status: PasteGoStatus;
+}) => {
+  safeTrack("paste_go_used", properties);
+};

--- a/lib/helpers/search.ts
+++ b/lib/helpers/search.ts
@@ -1,6 +1,11 @@
 import { useMainStore } from "../store/mainStore";
 import { useHistoryStore } from "../store/historyStore";
 import { validateCoords } from "./validation";
+import {
+  type CoordinateSearchErrorType,
+  type CoordinateSearchSource,
+  trackSearchCoordinates,
+} from "../analytics/events";
 
 export const parseInput = (searchInput: string) => {
   const store = useMainStore.getState();
@@ -36,8 +41,12 @@ export const parseInput = (searchInput: string) => {
 export const searchCoords = async (
   lat: number,
   lng: number,
-  addHistory = true
+  options: {
+    addHistory?: boolean;
+    source?: CoordinateSearchSource;
+  } = {}
 ) => {
+  const { addHistory = true, source = "search_panel" } = options;
   const historyStore = useHistoryStore.getState();
   console.log("searchCoords called", lat, lng);
   const store = useMainStore.getState();
@@ -53,14 +62,26 @@ export const searchCoords = async (
     const data = await res.json().catch(() => null);
     console.log("data", data);
 
-    if (res.ok && Array.isArray(data)) {
+    const success = res.ok && Array.isArray(data);
+    const resultCount = success ? data.length : 0;
+    let errorType: CoordinateSearchErrorType = "none";
+
+    if (success) {
       store.setCoordsResults(data);
     } else {
       store.setCoordsResults([]);
       // capture an error message for UI, but keep results empty
       const message = typeof data === "string" ? data : "No results";
       store.setSearchError(message);
+      errorType = res.status === 404 ? "no_results" : "request_failed";
     }
+
+    trackSearchCoordinates({
+      source,
+      success,
+      result_count: resultCount,
+      error_type: errorType,
+    });
 
     if (addHistory) {
       const resultText =
@@ -82,6 +103,12 @@ export const searchCoords = async (
     store.setSearchError(
       error instanceof Error ? error.message : "An error occurred"
     );
+    trackSearchCoordinates({
+      source,
+      success: false,
+      result_count: 0,
+      error_type: "request_failed",
+    });
   } finally {
     store.setSearchingCoords(false);
     store.setSidebarTab("results");


### PR DESCRIPTION
Introduce analytics (lib/analytics/events.ts) and wire tracking across the app: instrument coordinate searches with a source and options in lib/helpers/search.ts, and emit search events with success/result_count/error_type. Add event calls for map double-click, history replay (small/large), paste-&-go (with success/invalid/error statuses), name searches, and opening the service area reference. Also remove an unused import in history cards and pass addHistory:false when replaying history results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-visible analytics: tracking for coordinate searches (including source), name searches, paste‑and‑go, history replay usage, and opening service area reference.
  * Paste & Go now reports status for success, invalid clipboard, and clipboard errors.

* **Bug Fixes**
  * Improved search error handling and user-facing error messages.

* **Refactor**
  * Unified coordinate search flow to support richer tracking and error classification across search entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->